### PR TITLE
Added metadata to fix template.

### DIFF
--- a/python-sample-app.yaml
+++ b/python-sample-app.yaml
@@ -39,7 +39,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: python:3.5
+          name: python:2.7
           namespace: openshift
       type: Source
     triggers:
@@ -127,4 +127,10 @@ objects:
     to:
       kind: Service
       name: python-sample-app
-metadata: {}
+metadata:
+  name: python-sample-app
+  annotations:
+    openshift.io/display-name: "python-sample-app"
+    description: "jumpgate"
+    tags: python
+    iconClass: icon-python


### PR DESCRIPTION
Added name into metadata field so when you push a template up to OpenShift using the command ```oc create -f openshift/templates/python-sample-app.yaml```

Also changed python version to 2.7 and added annotations to metadata so the template shows up under the "Python" section of templates.